### PR TITLE
docs: Link to Kurtosis monorepo as part of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 My Package
 ============
-This is a [Kurtosis package](https://docs.kurtosis.com/concepts-reference/packages). It doesn't do much now, but it will soon!
+This is a [Kurtosis](https://github.com/kurtosis-tech/kurtosis/) package. It doesn't do much now, but it will soon!
 
 Run this package
 ----------------


### PR DESCRIPTION
Link to the monorepo, rather than to a page deep in our docs, so users get a gentler introduction to Kurtosis.