### PR TITLE
Add documentation on importing a package from a branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ this_package = import_module("github.com/YOURUSER/THISREPO/main.star")
 this_package = import_module(".src/main.star")
 ```
 
-If you want to use a fork or specific version of this package in your own package, you can replace the dependencies in your `kurtosis.yml` file using the [Replace](https://docs.kurtosis.com/concepts-reference/kurtosis-yml/#replace) primitive. 
+If you want to use a fork or specific version of this package in your own package, you can replace the dependencies in your `kurtosis.yml` file using the [replace](https://docs.kurtosis.com/concepts-reference/kurtosis-yml/#replace) primitive. 
 Within your `kurtosis.yml` file:
 ```python
 name: github.com/example-org/example-repo

--- a/README.md
+++ b/README.md
@@ -58,13 +58,19 @@ Kurtosis packages can be composed inside other Kurtosis packages. To use this pa
 First, import this package by adding the following to the top of your Starlark file:
 
 ```python
-this_package = import_module("github.com/YOURUSER/THISREPO/main.star")
+# For remote packages:
+this_package = import_module("github.com/YOURUSER/THISREPO/main.star") 
+
+# For local packages:
+this_package = import_module(".src/main.star")
 ```
 
-If you want to import the package from a branch other than main, you can update the import command to:
-
+If you want to use a fork or specific version of this package in your own package, you can replace the dependencies in your `kurtosis.yml` file using the [Replace](https://docs.kurtosis.com/concepts-reference/kurtosis-yml/#replace) primitive. 
+Within your `kurtosis.yml` file:
 ```python
-this_package = import_module("github.com/YOURUSER/THISREPO/main.star@YOURBRANCH")
+name: github.com/example-org/example-repo
+replace:
+    github.com/YOURUSER/THISREPO: github.com/YOURUSER/THISREPO@YOURBRANCH
 ```
 
 Then, call the this package's `run` function somewhere in your Starlark script:

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ First, import this package by adding the following to the top of your Starlark f
 this_package = import_module("github.com/YOURUSER/THISREPO/main.star")
 ```
 
+If you want to import the package from a branch other than main, you can update the import command to:
+
+```python
+this_package = import_module("github.com/YOURUSER/THISREPO/main.star@YOURBRANCH")
+```
+
 Then, call the this package's `run` function somewhere in your Starlark script:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Kurtosis packages can be composed inside other Kurtosis packages. To use this pa
 First, import this package by adding the following to the top of your Starlark file:
 
 ```python
-# For remote packages:
+# For remote packages: 
 this_package = import_module("github.com/YOURUSER/THISREPO/main.star") 
 
 # For local packages:


### PR DESCRIPTION
I believe when someone is creating a package, they will have their dev code in a `dev` branch or so and will ideally not want to push all their code to main. It ll be useful to let them know how to import a module from a branch